### PR TITLE
link na stronie prelegenta przekierowuje na confiturę

### DIFF
--- a/src/app/shared/social-links/social-links.component.ts
+++ b/src/app/shared/social-links/social-links.component.ts
@@ -17,8 +17,8 @@ export class SocialLinksComponent implements OnInit {
   }
 
   ngOnInit() {
-    if (this.www && !this.www.startsWith("http")) {
-      this.www = "http://" + this.www;
+    if (this.www && !this.www.startsWith('http')) {
+      this.www = 'http://' + this.www;
     }
   }
 

--- a/src/app/shared/social-links/social-links.component.ts
+++ b/src/app/shared/social-links/social-links.component.ts
@@ -17,6 +17,9 @@ export class SocialLinksComponent implements OnInit {
   }
 
   ngOnInit() {
+    if (this.www && !this.www.startsWith("http")) {
+      this.www = "http://" + this.www;
+    }
   }
 
 }


### PR DESCRIPTION
"jak się w profilu wpisze adres strony jak na obrazku poniżej, to finalny link jest https://2018.confitura.pl/thingsandstuff.eu i prowadzi do https://2018.confitura.pl/ finalnie"

obrazek: thingsandstuff.eu